### PR TITLE
Fixing a difference in the naming between metafield namespace we send in the graphql query and the one we pull

### DIFF
--- a/app/routes/app.discounts-allocator.$functionId.jsx
+++ b/app/routes/app.discounts-allocator.$functionId.jsx
@@ -27,7 +27,7 @@ export const action = async ({ params, request }) => {
 
     const response = await admin.graphql(registerDiscountsAllocatorMutation, {
       variables: {
-        functionExtensionId: JSON.parse(functionExtensionId),
+        functionExtensionId: functionExtensionId,
       },
     });
 

--- a/app/shopify.server.js
+++ b/app/shopify.server.js
@@ -8,10 +8,12 @@ import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prism
 import { restResources } from "@shopify/shopify-api/rest/admin/2024-07";
 import prisma from "./db.server";
 
+export const apiVersion = ApiVersion.Unstable;
+
 const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
   apiSecretKey: process.env.SHOPIFY_API_SECRET || "",
-  apiVersion: ApiVersion.July24,
+  apiVersion: apiVersion,
   scopes: process.env.SCOPES?.split(","),
   appUrl: process.env.SHOPIFY_APP_URL || "",
   authPathPrefix: "/auth",
@@ -27,7 +29,6 @@ const shopify = shopifyApp({
 });
 
 export default shopify;
-export const apiVersion = ApiVersion.July24;
 export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
 export const authenticate = shopify.authenticate;
 export const unauthenticated = shopify.unauthenticated;

--- a/extensions/product-discount-js/src/run.graphql
+++ b/extensions/product-discount-js/src/run.graphql
@@ -7,7 +7,7 @@ query RunInput {
   }
   # [START build-the-ui.use-namespace]
   discountNode {
-    metafield(namespace: "volume-discount", key: "function-configuration") {
+    metafield(namespace: "$app:volume-discount", key: "function-configuration") {
       value
     }
   }


### PR DESCRIPTION
## Description

This PR fixes the code presented in the tutorial at this page [build-ui-with-remix](https://shopify.dev/docs/apps/build/discounts/build-ui-with-remix?extension=javascript).

We were sending the metafield namespace "$app:volume-discount" in `app.volume-discount.$functionId.new.jsx` but were pulling the metafield with the namespace "volume-discount" in the graphql query